### PR TITLE
[fix] Image download stream error handling

### DIFF
--- a/src/commands/database/download.ts
+++ b/src/commands/database/download.ts
@@ -26,6 +26,7 @@ export default class DownloadCommand extends BaseCommand {
       new NinoxProjectService(fsUtil),
       new NinoxClient(this.environment as EnvironmentConfig),
       this.environment.workspaceId,
+      this.debug,
     )
   }
 

--- a/src/commands/database/list.ts
+++ b/src/commands/database/list.ts
@@ -21,6 +21,7 @@ export default class ListCommand extends BaseCommand {
       new NinoxProjectService(new FSUtil()),
       new NinoxClient(this.environment as EnvironmentConfig),
       this.environment.workspaceId,
+      () => {},
     )
   }
 

--- a/src/commands/database/upload.ts
+++ b/src/commands/database/upload.ts
@@ -27,6 +27,7 @@ export default class UploadCommand extends BaseCommand {
       new NinoxProjectService(fsUtil),
       new NinoxClient(this.environment as EnvironmentConfig),
       this.environment.workspaceId,
+      this.debug,
     )
   }
 

--- a/src/core/services/database-service.spec.ts
+++ b/src/core/services/database-service.spec.ts
@@ -43,7 +43,7 @@ describe('DatabaseService', () => {
   beforeEach(() => {
     ninoxClientStub = sinon.createStubInstance(NinoxClient)
     ninoxProjectServiceStub = sinon.createStubInstance(NinoxProjectService)
-    databaseService = new DatabaseService(ninoxProjectServiceStub, ninoxClientStub, 'workspaceId', databaseId)
+    databaseService = new DatabaseService(ninoxProjectServiceStub, ninoxClientStub, 'workspaceId', () => {})
   })
 
   afterEach(() => {


### PR DESCRIPTION
When downloading Database background Image, if there's an Axios exception, the axios.request had an open handle, which kept the node process from exiting. So in the case of error the streaming request should be ended with `request.abort()`