### PR TITLE
fix: [ND-7819] bug fix refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ npm install -g @ninox/ninox
 $ ninox COMMAND
 running command...
 $ ninox (--version)
-@ninox/ninox/0.1.1 darwin-arm64 node-v20.14.0
+@ninox/ninox/0.1.2 darwin-arm64 node-v20.15.0
 $ ninox --help [COMMAND]
 USAGE
   $ ninox COMMAND
@@ -52,7 +52,7 @@ EXAMPLES
   $ ninox DEV database download -i 1234
 ```
 
-_See code: [src/commands/database/download.ts](https://github.com/ninoxdb/ninox-dev-cli/blob/v0.1.1/src/commands/database/download.ts)_
+_See code: [src/commands/database/download.ts](https://github.com/ninoxdb/ninox-dev-cli/blob/v0.1.2/src/commands/database/download.ts)_
 
 ## `ninox database list`
 
@@ -69,7 +69,7 @@ EXAMPLES
   $ ninox DEV database list
 ```
 
-_See code: [src/commands/database/list.ts](https://github.com/ninoxdb/ninox-dev-cli/blob/v0.1.1/src/commands/database/list.ts)_
+_See code: [src/commands/database/list.ts](https://github.com/ninoxdb/ninox-dev-cli/blob/v0.1.2/src/commands/database/list.ts)_
 
 ## `ninox database upload`
 
@@ -89,7 +89,7 @@ EXAMPLES
   $ ninox DEV database upload -i 1234
 ```
 
-_See code: [src/commands/database/upload.ts](https://github.com/ninoxdb/ninox-dev-cli/blob/v0.1.1/src/commands/database/upload.ts)_
+_See code: [src/commands/database/upload.ts](https://github.com/ninoxdb/ninox-dev-cli/blob/v0.1.2/src/commands/database/upload.ts)_
 
 ## `ninox project init NAME`
 
@@ -109,5 +109,5 @@ EXAMPLES
   $ ninox project init
 ```
 
-_See code: [src/commands/project/init.ts](https://github.com/ninoxdb/ninox-dev-cli/blob/v0.1.1/src/commands/project/init.ts)_
+_See code: [src/commands/project/init.ts](https://github.com/ninoxdb/ninox-dev-cli/blob/v0.1.2/src/commands/project/init.ts)_
 <!-- commandsstop -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninox/ninox",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninox/ninox",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "form-data": "^4.0.0",
         "js-yaml": "^4.1.0",
         "ora": "^8.0.1",
+        "tty-table": "^4.2.3",
         "zod": "^3.23.6"
       },
       "bin": {
@@ -58025,7 +58026,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
       "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "is-array-buffer": "^3.0.4"
@@ -58089,7 +58089,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
       "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
@@ -58125,7 +58124,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
       "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
-      "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
         "call-bind": "^1.0.5",
@@ -58183,7 +58181,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -58246,6 +58243,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/breakword": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/breakword/-/breakword-1.0.6.tgz",
+      "integrity": "sha512-yjxDAYyK/pBvws9H4xKYpLDpYKEH6CzrBPAuXq3x18I+c/2MkVtT3qAr7Oloi6Dss9qNhPVueAAVU1CSeNDIXw==",
+      "dependencies": {
+        "wcwidth": "^1.0.1"
+      }
+    },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -58304,7 +58309,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
       "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -58594,6 +58598,14 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -58683,11 +58695,39 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csv": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-5.5.3.tgz",
+      "integrity": "sha512-QTaY0XjjhTQOdguARF0lGKm5/mEq9PD9/VhZZegHDIBq2tQwgNpHc3dneD4mGo2iJs+fTKv5Bp0fZ+BRuY3Z0g==",
+      "dependencies": {
+        "csv-generate": "^3.4.3",
+        "csv-parse": "^4.16.3",
+        "csv-stringify": "^5.6.5",
+        "stream-transform": "^2.1.3"
+      },
+      "engines": {
+        "node": ">= 0.1.90"
+      }
+    },
+    "node_modules/csv-generate": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-3.4.3.tgz",
+      "integrity": "sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw=="
+    },
+    "node_modules/csv-parse": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
+      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
+    },
+    "node_modules/csv-stringify": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
+      "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
       "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -58704,7 +58744,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
       "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -58721,7 +58760,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
       "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -58807,6 +58845,17 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -58820,7 +58869,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -58837,7 +58885,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -58966,7 +59013,6 @@
       "version": "1.23.3",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
       "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
-      "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
         "arraybuffer.prototype.slice": "^1.0.3",
@@ -59026,7 +59072,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
       "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.4"
       },
@@ -59038,7 +59083,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -59047,7 +59091,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
       "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -59059,7 +59102,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
       "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.4",
         "has-tostringtag": "^1.0.2",
@@ -59073,7 +59115,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
       "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
-      "dev": true,
       "dependencies": {
         "hasown": "^2.0.0"
       }
@@ -59082,7 +59123,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "dependencies": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -59099,7 +59139,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
       "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -60022,7 +60061,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
       }
@@ -60087,7 +60125,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -60096,7 +60133,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
       "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
@@ -60114,7 +60150,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -60123,7 +60158,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -60152,7 +60186,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
@@ -60203,7 +60236,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
       "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "es-errors": "^1.3.0",
@@ -60317,7 +60349,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -60352,7 +60383,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -60391,6 +60421,11 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -60401,7 +60436,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
       "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -60418,7 +60452,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -60430,7 +60463,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
       "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -60442,7 +60474,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -60454,7 +60485,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -60469,7 +60499,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -60605,7 +60634,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
       "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "hasown": "^2.0.0",
@@ -60628,7 +60656,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
       "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.1"
@@ -60650,7 +60677,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-      "dev": true,
       "dependencies": {
         "has-bigints": "^1.0.1"
       },
@@ -60674,7 +60700,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -60705,7 +60730,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -60729,7 +60753,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
       "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
-      "dev": true,
       "dependencies": {
         "is-typed-array": "^1.1.13"
       },
@@ -60744,7 +60767,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -60811,7 +60833,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
       "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -60831,7 +60852,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -60867,7 +60887,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -60883,7 +60902,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7"
       },
@@ -60898,7 +60916,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -60913,7 +60930,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -60928,7 +60944,6 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
       "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
-      "dev": true,
       "dependencies": {
         "which-typed-array": "^1.1.14"
       },
@@ -60955,7 +60970,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2"
       },
@@ -60977,8 +60991,7 @@
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -61115,6 +61128,14 @@
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -61324,6 +61345,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mixme": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.10.tgz",
+      "integrity": "sha512-5H76ANWinB1H3twpJ6JY8uvAtpmFvHNArpilJAjXRKXSDDLPIMoZArw5SH0q9z+lLs8IrMw7Q2VWpWimFKFT1Q==",
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/mocha": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.4.0.tgz",
@@ -61494,7 +61523,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -61503,7 +61531,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -61520,7 +61547,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
       "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "define-properties": "^1.2.1",
@@ -61820,7 +61846,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -61898,7 +61923,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -61979,7 +62003,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -62264,7 +62287,6 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
       "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "define-properties": "^1.2.1",
@@ -62315,10 +62337,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -62497,7 +62523,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
       "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "get-intrinsic": "^1.2.4",
@@ -62535,7 +62560,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
       "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -62583,11 +62607,15 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -62604,7 +62632,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -62713,7 +62740,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -62813,6 +62839,150 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/smartwrap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/smartwrap/-/smartwrap-2.0.2.tgz",
+      "integrity": "sha512-vCsKNQxb7PnCNd2wY1WClWifAc2lwqsG8OaswpJkVJsvMGcnEntdTCDajZCkk93Ay1U3t/9puJmb525Rg5MZBA==",
+      "dependencies": {
+        "array.prototype.flat": "^1.2.3",
+        "breakword": "^1.0.5",
+        "grapheme-splitter": "^1.0.4",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1",
+        "yargs": "^15.1.0"
+      },
+      "bin": {
+        "smartwrap": "src/terminal-adapter.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/smartwrap/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/smartwrap/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/smartwrap/node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/smartwrap/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smartwrap/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smartwrap/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/smartwrap/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smartwrap/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smartwrap/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "node_modules/smartwrap/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smartwrap/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/snake-case": {
@@ -62942,6 +63112,14 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/stream-transform": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.3.tgz",
+      "integrity": "sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==",
+      "dependencies": {
+        "mixme": "^0.5.1"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -62959,7 +63137,6 @@
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
       "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -62977,7 +63154,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
       "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -62991,7 +63167,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -63226,6 +63401,64 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
+    "node_modules/tty-table": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/tty-table/-/tty-table-4.2.3.tgz",
+      "integrity": "sha512-Fs15mu0vGzCrj8fmJNP7Ynxt5J7praPXqFN0leZeZBXJwkMxv9cb2D454k1ltrtUSJbZ4yH4e0CynsHLxmUfFA==",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "csv": "^5.5.3",
+        "kleur": "^4.1.5",
+        "smartwrap": "^2.0.2",
+        "strip-ansi": "^6.0.1",
+        "wcwidth": "^1.0.1",
+        "yargs": "^17.7.1"
+      },
+      "bin": {
+        "tty-table": "adapters/terminal-adapter.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/tty-table/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tty-table/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tty-table/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -63262,7 +63495,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
       "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -63276,7 +63508,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
       "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -63295,7 +63526,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
       "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
-      "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",
@@ -63315,7 +63545,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
       "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -63348,7 +63577,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
       "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -63441,6 +63669,14 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -63459,7 +63695,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "dev": true,
       "dependencies": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -63471,11 +63706,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
       "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
-      "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",
@@ -63547,7 +63786,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninox/ninox",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninox/ninox",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^3",
@@ -17,6 +17,7 @@
         "debug": "^4.3.4",
         "form-data": "^4.0.0",
         "js-yaml": "^4.1.0",
+        "ora": "^8.0.1",
         "zod": "^3.23.6"
       },
       "bin": {
@@ -58537,6 +58538,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-progress": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
@@ -58552,7 +58567,6 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -60114,6 +60128,17 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
+      "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -60771,6 +60796,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -61236,6 +61272,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
@@ -61586,6 +61630,20 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -61601,6 +61659,122 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.0.1.tgz",
+      "integrity": "sha512-ANIvzobt1rls2BDny5fWZ3ZVKyD6nscLvfFRpQgfWsythlcsVUC9kL0zq6j2Z5z9wwp1kd7wpsD/T9qNPVLCaQ==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^4.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw=="
+    },
+    "node_modules/ora/node_modules/is-unicode-supported": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
+      "integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
+      "integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/p-cancelable": {
@@ -62202,6 +62376,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -62723,6 +62917,17 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/stdout-stderr": {
       "version": "0.1.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
         "axios": "^1.6.8",
         "debug": "^4.3.4",
         "form-data": "^4.0.0",
-        "js-yaml": "^4.1.0",
         "ora": "^8.0.1",
         "tty-table": "^4.2.3",
+        "yaml": "^2.4.5",
         "zod": "^3.23.6"
       },
       "bin": {
@@ -58020,7 +58020,8 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.1",
@@ -61045,6 +61046,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -63795,6 +63797,17 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "form-data": "^4.0.0",
     "js-yaml": "^4.1.0",
     "ora": "^8.0.1",
+    "tty-table": "^4.2.3",
     "zod": "^3.23.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "axios": "^1.6.8",
     "debug": "^4.3.4",
     "form-data": "^4.0.0",
-    "js-yaml": "^4.1.0",
     "ora": "^8.0.1",
     "tty-table": "^4.2.3",
+    "yaml": "^2.4.5",
     "zod": "^3.23.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "debug": "^4.3.4",
     "form-data": "^4.0.0",
     "js-yaml": "^4.1.0",
+    "ora": "^8.0.1",
     "zod": "^3.23.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ninox/ninox",
   "description": "Ninox Database CLI for developer workflows",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Muhammad Saqib Arfeen<saqib.arfeen@ninox.com>",
   "bin": {
     "ninox": "./bin/run.js"

--- a/src/commands/database/download.ts
+++ b/src/commands/database/download.ts
@@ -1,4 +1,5 @@
 import {Flags} from '@oclif/core'
+import ora from 'ora'
 
 import {BaseCommand} from '../../core/base.js'
 import {EnvironmentConfig} from '../../core/common/types.js'
@@ -22,6 +23,7 @@ export default class DownloadCommand extends BaseCommand {
   protected async init(): Promise<void> {
     await super.init()
     const {flags} = await this.parse(DownloadCommand)
+    if (process.env.NODE_ENV !== 'test') this.spinner = ora(`Downloading Database ${flags.id}\n`).start()
     const fsUtil = new FSUtil()
     const context = {debug: this.debug}
     this.databaseService = new DatabaseService(
@@ -34,6 +36,7 @@ export default class DownloadCommand extends BaseCommand {
 
   public async run(): Promise<void> {
     await this.databaseService.download()
+    this.spinner?.stop()
     this.debug(`success src/commands/download.ts`)
     this.log(
       `Downloaded database ${this.databaseService.getDBName()} (${this.databaseService.getDBId()}) successfully!`,

--- a/src/commands/database/download.ts
+++ b/src/commands/database/download.ts
@@ -8,6 +8,7 @@ import {INinoxObjectService} from '../../core/services/interfaces.js'
 import {NinoxProjectService} from '../../core/services/ninoxproject-service.js'
 import {FSUtil} from '../../core/utils/fs.js'
 import {NinoxClient} from '../../core/utils/ninox-client.js'
+import {isTest} from '../../core/utils/util.js'
 
 export default class DownloadCommand extends BaseCommand {
   public static override description =
@@ -23,7 +24,7 @@ export default class DownloadCommand extends BaseCommand {
   protected async init(): Promise<void> {
     await super.init()
     const {flags} = await this.parse(DownloadCommand)
-    if (process.env.NODE_ENV !== 'test') this.spinner = ora(`Downloading Database ${flags.id}\n`).start()
+    if (!isTest()) this.spinner = ora(`Downloading Database ${flags.id}\n`).start()
     const fsUtil = new FSUtil()
     const context = {debug: this.debug}
     this.databaseService = new DatabaseService(

--- a/src/commands/database/list.ts
+++ b/src/commands/database/list.ts
@@ -1,3 +1,5 @@
+import ora from 'ora'
+
 import {BaseCommand} from '../../core/base.js'
 import {DatabaseMetadata} from '../../core/common/schema-validators.js'
 import {EnvironmentConfig} from '../../core/common/types.js'
@@ -17,6 +19,8 @@ export default class ListCommand extends BaseCommand {
 
   protected async init(): Promise<void> {
     await super.init()
+    if (process.env.NODE_ENV !== 'test')
+      this.spinner = ora(`Listing all Databases in the workspace ${this.environment.workspaceId}\n`).start()
     const context = {debug: this.debug}
     this.databaseService = new DatabaseService(
       new NinoxProjectService(new FSUtil(), context),
@@ -32,6 +36,7 @@ export default class ListCommand extends BaseCommand {
       this.log(database.name, database.id)
     }
 
+    this.spinner?.stop()
     this.debug(`success src/commands/list.ts`)
   }
 }

--- a/src/commands/database/list.ts
+++ b/src/commands/database/list.ts
@@ -1,5 +1,4 @@
 import ora from 'ora'
-import table from 'tty-table'
 
 import {BaseCommand} from '../../core/base.js'
 import {DatabaseMetadata} from '../../core/common/schema-validators.js'
@@ -9,7 +8,7 @@ import {INinoxObjectService} from '../../core/services/interfaces.js'
 import {NinoxProjectService} from '../../core/services/ninoxproject-service.js'
 import {FSUtil} from '../../core/utils/fs.js'
 import {NinoxClient} from '../../core/utils/ninox-client.js'
-import {isTest} from '../../core/utils/util.js'
+import {isTest, renderDatabaseListAsTable} from '../../core/utils/util.js'
 export default class ListCommand extends BaseCommand {
   public static override description =
     'List all the database names and ids in the Ninox cloud server. The ENV argument comes before the command name.'
@@ -33,19 +32,7 @@ export default class ListCommand extends BaseCommand {
   public async run(): Promise<void> {
     await this.parse(ListCommand)
     const dbs = await this.databaseService.list()
-    const ANSI = table(
-      [
-        {alias: '#', value: 'idx'},
-        {alias: 'Database name', align: 'left', headerAlign: 'left', value: 'name', width: 20},
-        {alias: 'Database ID', value: 'id'},
-      ],
-      dbs.map((database, index) => ({...database, idx: index + 1})),
-      [],
-      {
-        borderColor: 'green',
-        borderStyle: 'solid',
-      },
-    ).render()
+    const ANSI = renderDatabaseListAsTable(dbs)
     this.log(`${ANSI}\n`)
 
     this.spinner?.stop()

--- a/src/commands/database/list.ts
+++ b/src/commands/database/list.ts
@@ -9,6 +9,7 @@ import {INinoxObjectService} from '../../core/services/interfaces.js'
 import {NinoxProjectService} from '../../core/services/ninoxproject-service.js'
 import {FSUtil} from '../../core/utils/fs.js'
 import {NinoxClient} from '../../core/utils/ninox-client.js'
+import {isTest} from '../../core/utils/util.js'
 export default class ListCommand extends BaseCommand {
   public static override description =
     'List all the database names and ids in the Ninox cloud server. The ENV argument comes before the command name.'
@@ -19,7 +20,7 @@ export default class ListCommand extends BaseCommand {
 
   protected async init(): Promise<void> {
     await super.init()
-    if (process.env.NODE_ENV !== 'test')
+    if (!isTest())
       this.spinner = ora(`Listing all Databases in the workspace ${this.environment.workspaceId}\n`).start()
     const context = {debug: this.debug}
     this.databaseService = new DatabaseService(

--- a/src/commands/database/list.ts
+++ b/src/commands/database/list.ts
@@ -1,4 +1,5 @@
 import ora from 'ora'
+import table from 'tty-table'
 
 import {BaseCommand} from '../../core/base.js'
 import {DatabaseMetadata} from '../../core/common/schema-validators.js'
@@ -8,7 +9,6 @@ import {INinoxObjectService} from '../../core/services/interfaces.js'
 import {NinoxProjectService} from '../../core/services/ninoxproject-service.js'
 import {FSUtil} from '../../core/utils/fs.js'
 import {NinoxClient} from '../../core/utils/ninox-client.js'
-
 export default class ListCommand extends BaseCommand {
   public static override description =
     'List all the database names and ids in the Ninox cloud server. The ENV argument comes before the command name.'
@@ -32,9 +32,20 @@ export default class ListCommand extends BaseCommand {
   public async run(): Promise<void> {
     await this.parse(ListCommand)
     const dbs = await this.databaseService.list()
-    for (const database of dbs) {
-      this.log(database.name, database.id)
-    }
+    const ANSI = table(
+      [
+        {alias: '#', value: 'idx'},
+        {alias: 'Database name', align: 'left', headerAlign: 'left', value: 'name', width: 20},
+        {alias: 'Database ID', value: 'id'},
+      ],
+      dbs.map((database, index) => ({...database, idx: index + 1})),
+      [],
+      {
+        borderColor: 'green',
+        borderStyle: 'solid',
+      },
+    ).render()
+    this.log(`${ANSI}\n`)
 
     this.spinner?.stop()
     this.debug(`success src/commands/list.ts`)

--- a/src/commands/database/upload.ts
+++ b/src/commands/database/upload.ts
@@ -1,4 +1,5 @@
 import {Flags} from '@oclif/core'
+import ora from 'ora'
 
 import {BaseCommand} from '../../core/base.js'
 import {EnvironmentConfig} from '../../core/common/types.js'
@@ -23,6 +24,7 @@ export default class UploadCommand extends BaseCommand {
   protected async init(): Promise<void> {
     await super.init()
     const {flags} = await this.parse(UploadCommand)
+    if (process.env.NODE_ENV !== 'test') this.spinner = ora(`Uploading Database ${flags.id}\n`).start()
     const context = {debug: this.debug}
     const fsUtil = new FSUtil()
     this.databaseService = new DatabaseService(
@@ -35,6 +37,7 @@ export default class UploadCommand extends BaseCommand {
 
   public async run(): Promise<void> {
     await this.databaseService.upload()
+    this.spinner?.stop()
     this.debug(`success src/commands/upload.ts`)
     this.log(`Uploaded database ${this.databaseService.getDBId()} successfully!`)
   }

--- a/src/commands/database/upload.ts
+++ b/src/commands/database/upload.ts
@@ -8,6 +8,7 @@ import {INinoxObjectService} from '../../core/services/interfaces.js'
 import {NinoxProjectService} from '../../core/services/ninoxproject-service.js'
 import {FSUtil} from '../../core/utils/fs.js'
 import {NinoxClient} from '../../core/utils/ninox-client.js'
+import {isTest} from '../../core/utils/util.js'
 
 export default class UploadCommand extends BaseCommand {
   public static override description =
@@ -24,7 +25,7 @@ export default class UploadCommand extends BaseCommand {
   protected async init(): Promise<void> {
     await super.init()
     const {flags} = await this.parse(UploadCommand)
-    if (process.env.NODE_ENV !== 'test') this.spinner = ora(`Uploading Database ${flags.id}\n`).start()
+    if (!isTest()) this.spinner = ora(`Uploading Database ${flags.id}\n`).start()
     const context = {debug: this.debug}
     const fsUtil = new FSUtil()
     this.databaseService = new DatabaseService(

--- a/src/core/base.ts
+++ b/src/core/base.ts
@@ -2,7 +2,7 @@ import {Args, Command} from '@oclif/core'
 import {Ora} from 'ora'
 
 import {EnvironmentConfig} from './common/types.js'
-import {getEnvironment} from './utils/config.js'
+import {getEnvironment} from './utils/util.js'
 
 export abstract class BaseCommand extends Command {
   public static override args = {

--- a/src/core/base.ts
+++ b/src/core/base.ts
@@ -1,4 +1,5 @@
 import {Args, Command} from '@oclif/core'
+import {Ora} from 'ora'
 
 import {EnvironmentConfig} from './common/types.js'
 import {getEnvironment} from './utils/config.js'
@@ -9,6 +10,8 @@ export abstract class BaseCommand extends Command {
   }
 
   protected environment: EnvironmentConfig = {apiKey: '', domain: '', workspaceId: ''}
+
+  protected spinner!: Ora
 
   protected async init(): Promise<void> {
     await super.init()

--- a/src/core/common/schema-validators.ts
+++ b/src/core/common/schema-validators.ts
@@ -81,7 +81,7 @@ export const TableBase = z.object({
   icon: z.string().optional(),
   kind: z.enum(['table', 'page']),
   nextFieldId: z.number(),
-  order: z.union([z.number(), z.null()]),
+  order: z.union([z.number(), z.null()]).optional(),
   readRoles: z.array(z.string()).optional(),
   uis: z.record(z.any()),
   uuid: z.string(),
@@ -119,7 +119,7 @@ export const DatabaseSchemaForUpload = z.object({
       }),
     )
     .optional(),
-  seq: z.number(),
+  seq: z.number().optional(),
   version: z.number(),
 })
 
@@ -207,8 +207,8 @@ export const ViewTypeSchema = z.object({
   id: z.string(),
   kanbanDisableCreate: z.boolean().optional(),
   mode: z.string().optional(),
-  order: z.number(),
-  seq: z.number(),
+  order: z.number().optional(),
+  seq: z.number().optional(),
   type: z.string(),
 })
 

--- a/src/core/services/database-service.spec.ts
+++ b/src/core/services/database-service.spec.ts
@@ -95,8 +95,8 @@ describe('DatabaseService', () => {
       const mockBgImagePath = 'path/to/bg/image'
 
       ninoxClientStub.getDatabase.resolves(databaseJSONMock)
-      ninoxClientStub.listDatabaseViews.resolves([])
-      ninoxClientStub.listDatabaseReports.resolves([])
+      ninoxClientStub.getDatabaseViews.resolves([])
+      ninoxClientStub.getDatabaseReports.resolves([])
       // TODO: mock views
       ninoxProjectServiceStub.parseDatabaseConfigs.returns({
         database: databaseInfoMock,

--- a/src/core/services/database-service.ts
+++ b/src/core/services/database-service.ts
@@ -47,6 +47,15 @@ export class DatabaseService implements INinoxObjectService<DatabaseMetadata> {
     this.debug(`Downloading background image for Database ${database.settings.name}...`)
     await ninoxProjectService.createDatabaseFolderInFiles()
     await ninoxClient.downloadDatabaseBackgroundImage(databaseId, ninoxProjectService.getDbBackgroundImagePath())
+    // download report files
+    for (const {report} of reports) {
+      // eslint-disable-next-line no-await-in-loop
+      await ninoxClient.downloadReportFiles(
+        databaseId,
+        report.id,
+        ninoxProjectService.getReportFilesFolderPath(report.id),
+      )
+    }
   }
 
   public getDBId(): string {

--- a/src/core/services/interfaces.ts
+++ b/src/core/services/interfaces.ts
@@ -21,6 +21,7 @@ export interface INinoxObjectService<T> {
 export interface IProjectService {
   createDatabaseFolderInFiles(): Promise<void>
   getDbBackgroundImagePath(): string
+  getReportFilesFolderPath(reportId: string): string
   initialiseProject(name: string): Promise<void>
   isDbBackgroundImageExist(): boolean
   parseDatabaseConfigs(

--- a/src/core/services/ninoxproject-service.ts
+++ b/src/core/services/ninoxproject-service.ts
@@ -130,6 +130,10 @@ export class NinoxProjectService implements IProjectService {
     return this.dbBackgroundImagePath
   }
 
+  public getReportFilesFolderPath(reportId: string): string {
+    return path.join(this.getDatabaseFilesPath(), `report_${reportId}`)
+  }
+
   public async initialiseProject(name: string): Promise<void> {
     await this.createPackageJson(name)
     await this.createConfigYaml()

--- a/src/core/services/ninoxproject-service.ts
+++ b/src/core/services/ninoxproject-service.ts
@@ -480,7 +480,6 @@ export class NinoxProjectService implements IProjectService {
     reports: Record<string, ReportTypeFile[]>,
     tableFolders: Record<string, string>,
   ): Promise<void> {
-    // TODO: check why report also contains view like structures for some databases e.g hrm
     const directoryPromises = Object.entries(reports).map(async ([, reports]) => {
       // assume that the table folder exists if defined
       const fileWritingPromises = reports.map((report) => {

--- a/src/core/services/ninoxproject-service.ts
+++ b/src/core/services/ninoxproject-service.ts
@@ -34,6 +34,7 @@ import {ContextOptions, DBConfigsYaml, TableFolderContent, View} from '../common
 import {FSUtil} from '../utils/fs.js'
 import {IProjectService} from './interfaces.js'
 
+const JSYAML_DEFAULT_OPTIONS = {lineWidth: -1}
 export class NinoxProjectService implements IProjectService {
   private basePath: string = process.cwd()
   private credentialsFilePath: string
@@ -435,6 +436,7 @@ export class NinoxProjectService implements IProjectService {
             schema: {...schema, _database: database.id},
           },
         }),
+        JSYAML_DEFAULT_OPTIONS,
       ),
     )
   }
@@ -450,7 +452,7 @@ export class NinoxProjectService implements IProjectService {
         const tablePath = tableFolders[report.report.tid]
 
         const reportFileName = `${this.fsUtil.formatObjectFilename('report', report.report.caption)}.yaml`
-        return this.fsUtil.writeFile(path.join(tablePath, reportFileName), yaml.dump(report))
+        return this.fsUtil.writeFile(path.join(tablePath, reportFileName), yaml.dump(report, JSYAML_DEFAULT_OPTIONS))
       })
 
       // Wait for all file writing promises in this directory to resolve
@@ -475,7 +477,10 @@ export class NinoxProjectService implements IProjectService {
       fileWritePromises.push(
         this.fsUtil.mkdir(tableFolderPath).then(() => {
           // write table file
-          this.fsUtil.writeFile(path.join(tableFolderPath, `${tableFolderName}.yaml`), yaml.dump(tableFileData))
+          this.fsUtil.writeFile(
+            path.join(tableFolderPath, `${tableFolderName}.yaml`),
+            yaml.dump(tableFileData, JSYAML_DEFAULT_OPTIONS),
+          )
         }),
       )
     }
@@ -494,7 +499,7 @@ export class NinoxProjectService implements IProjectService {
         const tablePath = tableFolders[view.view.type]
 
         const viewFileName = `${this.fsUtil.formatObjectFilename('view', view.view.caption)}.yaml`
-        return this.fsUtil.writeFile(path.join(tablePath, viewFileName), yaml.dump(view))
+        return this.fsUtil.writeFile(path.join(tablePath, viewFileName), yaml.dump(view, JSYAML_DEFAULT_OPTIONS))
       })
 
       // Wait for all file writing promises in this directory to resolve

--- a/src/core/services/ninoxproject-service.ts
+++ b/src/core/services/ninoxproject-service.ts
@@ -1,5 +1,5 @@
-import * as yaml from 'js-yaml'
 import path from 'node:path'
+import * as yaml from 'yaml'
 
 import {
   CREDENTIALS_FILE_NAME,
@@ -34,7 +34,7 @@ import {ContextOptions, DBConfigsYaml, TableFolderContent, View} from '../common
 import {FSUtil} from '../utils/fs.js'
 import {IProjectService} from './interfaces.js'
 
-const JSYAML_DEFAULT_OPTIONS = {lineWidth: -1}
+const YAML_DEFAULT_OPTIONS = {lineWidth: -1}
 export class NinoxProjectService implements IProjectService {
   private basePath: string = process.cwd()
   private credentialsFilePath: string
@@ -65,7 +65,7 @@ export class NinoxProjectService implements IProjectService {
       return
     }
 
-    await this.fsUtil.writeFile(this.credentialsFilePath, yaml.dump(ConfigYamlTemplate))
+    await this.fsUtil.writeFile(this.credentialsFilePath, yaml.stringify(ConfigYamlTemplate))
   }
 
   // create folder src/Files/Database_${databaseid}
@@ -231,10 +231,10 @@ export class NinoxProjectService implements IProjectService {
     dBConfigsYaml: DBConfigsYaml,
   ): [database: DatabaseType, schema: DatabaseSchemaType, views: ViewType[], reports: Report[]] {
     const {database: databaseFileContent, reports: reportsFileContent, tables, views: viewsFileContent} = dBConfigsYaml
-    const databaseLocal = yaml.load(databaseFileContent) as DatabaseFileType
-    const tablesLocal = tables.map((table) => yaml.load(table) as TableFileType)
-    const viewsLocal = viewsFileContent.map((view) => yaml.load(view) as ViewTypeFile)
-    const reportsLocal = reportsFileContent.map((report) => yaml.load(report) as ReportTypeFile)
+    const databaseLocal = yaml.parse(databaseFileContent) as DatabaseFileType
+    const tablesLocal = tables.map((table) => yaml.parse(table) as TableFileType)
+    const viewsLocal = viewsFileContent.map((view) => yaml.parse(view) as ViewTypeFile)
+    const reportsLocal = reportsFileContent.map((report) => yaml.parse(report) as ReportTypeFile)
     const {database: databaseJSON} = databaseLocal
     const {schema: schemaLocalJSON} = databaseJSON
 
@@ -464,14 +464,14 @@ export class NinoxProjectService implements IProjectService {
     )
     await this.fsUtil.writeFile(
       databaseFilePath,
-      yaml.dump(
+      yaml.stringify(
         DatabaseFile.parse({
           database: {
             ...database,
             schema: {...schema, _database: database.id},
           },
         }),
-        JSYAML_DEFAULT_OPTIONS,
+        YAML_DEFAULT_OPTIONS,
       ),
     )
   }
@@ -486,7 +486,7 @@ export class NinoxProjectService implements IProjectService {
         const tablePath = tableFolders[report.report.tid]
 
         const reportFileName = `${this.fsUtil.formatObjectFilename('report', report.report.caption)}.yaml`
-        return this.fsUtil.writeFile(path.join(tablePath, reportFileName), yaml.dump(report, JSYAML_DEFAULT_OPTIONS))
+        return this.fsUtil.writeFile(path.join(tablePath, reportFileName), yaml.stringify(report, YAML_DEFAULT_OPTIONS))
       })
 
       // Wait for all file writing promises in this directory to resolve
@@ -513,7 +513,7 @@ export class NinoxProjectService implements IProjectService {
           // write table file
           this.fsUtil.writeFile(
             path.join(tableFolderPath, `${tableFolderName}.yaml`),
-            yaml.dump(tableFileData, JSYAML_DEFAULT_OPTIONS),
+            yaml.stringify(tableFileData, YAML_DEFAULT_OPTIONS),
           )
         }),
       )
@@ -533,7 +533,7 @@ export class NinoxProjectService implements IProjectService {
         const tablePath = tableFolders[view.view.type]
 
         const viewFileName = `${this.fsUtil.formatObjectFilename('view', view.view.caption)}.yaml`
-        return this.fsUtil.writeFile(path.join(tablePath, viewFileName), yaml.dump(view, JSYAML_DEFAULT_OPTIONS))
+        return this.fsUtil.writeFile(path.join(tablePath, viewFileName), yaml.stringify(view, YAML_DEFAULT_OPTIONS))
       })
 
       // Wait for all file writing promises in this directory to resolve

--- a/src/core/utils/config.ts
+++ b/src/core/utils/config.ts
@@ -1,6 +1,6 @@
-import * as yaml from 'js-yaml'
 import fs from 'node:fs'
 import path from 'node:path'
+import * as yaml from 'yaml'
 
 import {CREDENTIALS_FILE_NAME} from '../common/constants.js'
 import {Config, EnvironmentConfig} from '../common/types.js'
@@ -13,7 +13,7 @@ export function readConfig(): Config {
     throw new Error(`Configuration file not found: ${configFile}`)
   }
 
-  return yaml.load(fs.readFileSync(configFile, 'utf8')) as Config
+  return yaml.parse(fs.readFileSync(configFile, 'utf8')) as Config
 }
 
 export function getEnvironment(environment: string): EnvironmentConfig {

--- a/src/core/utils/ninox-client.ts
+++ b/src/core/utils/ninox-client.ts
@@ -105,7 +105,7 @@ export class NinoxClient {
 
   public async getDatabase(id: string): Promise<GetDatabaseResponse> {
     return this.client
-      .get(`/v1/teams/${this.workspaceId}/databases/${id}?humanScript=T`)
+      .get(`/v1/teams/${this.workspaceId}/databases/${id}?formattedScripts=T`)
       .then((response) => response.data)
       .catch((error) => handleAxiosError(error, 'Failed to fetch database'))
   }
@@ -136,7 +136,7 @@ export class NinoxClient {
 
   public async patchDatabaseSchemaInNinox(id: string, schema: DatabaseSchemaType): Promise<unknown> {
     return this.client
-      .patch(`/v1/teams/${this.workspaceId}/databases/${id}/schema?humanScript=T`, schema)
+      .patch(`/v1/teams/${this.workspaceId}/databases/${id}/schema?formattedScripts=T`, schema)
       .then((response) => response.data)
       .catch((error) =>
         handleAxiosError(

--- a/src/core/utils/ninox-client.ts
+++ b/src/core/utils/ninox-client.ts
@@ -105,7 +105,7 @@ export class NinoxClient {
 
   public async getDatabase(id: string): Promise<GetDatabaseResponse> {
     return this.client
-      .get(`/v1/teams/${this.workspaceId}/databases/${id}?formattedScripts=T`)
+      .get(`/v1/teams/${this.workspaceId}/databases/${id}?formatScripts=T`)
       .then((response) => response.data)
       .catch((error) => handleAxiosError(error, 'Failed to fetch database'))
   }
@@ -136,7 +136,7 @@ export class NinoxClient {
 
   public async patchDatabaseSchemaInNinox(id: string, schema: DatabaseSchemaType): Promise<unknown> {
     return this.client
-      .patch(`/v1/teams/${this.workspaceId}/databases/${id}/schema?formattedScripts=T`, schema)
+      .patch(`/v1/teams/${this.workspaceId}/databases/${id}/schema?formatScripts=T`, schema)
       .then((response) => response.data)
       .catch((error) =>
         handleAxiosError(

--- a/src/core/utils/ninox-client.ts
+++ b/src/core/utils/ninox-client.ts
@@ -11,7 +11,7 @@ import {
   Report,
   ViewType,
 } from '../common/schema-validators.js'
-import {NinoxCredentials, View, ViewMetadata} from '../common/types.js'
+import {NinoxCredentials, View} from '../common/types.js'
 
 export class NinoxClient {
   private client: AxiosInstance
@@ -69,25 +69,18 @@ export class NinoxClient {
       .catch((error) => handleAxiosError(error, 'Failed to fetch database'))
   }
 
-  public async getDatabaseReport(databaseId: string, reportId: string): Promise<Report> {
+  public async getDatabaseReports(databaseId: string): Promise<Report[]> {
     return this.client
-      .get(`/v1/teams/${this.workspaceId}/databases/${databaseId}/reports/${reportId}`)
-      .then((response) => response.data)
-      .catch((error) => handleAxiosError(error, 'Failed to fetch database report'))
-  }
-
-  public async getDatabaseView(databaseId: string, viewId: string): Promise<View> {
-    return this.client
-      .get(`/v1/teams/${this.workspaceId}/databases/${databaseId}/views/${viewId}`)
-      .then((response) => response.data)
-      .catch((error) => handleAxiosError(error, 'Failed to fetch database views'))
-  }
-
-  public async listDatabaseReports(databaseId: string): Promise<Report[]> {
-    return this.client
-      .get(`/v1/teams/${this.workspaceId}/databases/${databaseId}/reports`)
+      .get(`/v1/teams/${this.workspaceId}/databases/${databaseId}/reports?fullReport=T`)
       .then((response) => response.data)
       .catch((error) => handleAxiosError(error, 'Failed to list database reports'))
+  }
+
+  public async getDatabaseViews(databaseId: string): Promise<View[]> {
+    return this.client
+      .get(`/v1/teams/${this.workspaceId}/databases/${databaseId}/views?fullView=T`)
+      .then((response) => response.data)
+      .catch((error) => handleAxiosError(error, 'Failed to list database views'))
   }
 
   public async listDatabases(): Promise<DatabaseMetadata[]> {
@@ -98,13 +91,6 @@ export class NinoxClient {
         handleAxiosError(error, 'Failed to list databases')
         return []
       })
-  }
-
-  public async listDatabaseViews(databaseId: string): Promise<ViewMetadata[]> {
-    return this.client
-      .get(`/v1/teams/${this.workspaceId}/databases/${databaseId}/views`)
-      .then((response) => response.data)
-      .catch((error) => handleAxiosError(error, 'Failed to list database views'))
   }
 
   public async patchDatabaseSchemaInNinox(id: string, schema: DatabaseSchemaType): Promise<unknown> {

--- a/src/core/utils/ninox-client.ts
+++ b/src/core/utils/ninox-client.ts
@@ -105,7 +105,7 @@ export class NinoxClient {
 
   public async getDatabase(id: string): Promise<GetDatabaseResponse> {
     return this.client
-      .get(`/v1/teams/${this.workspaceId}/databases/${id}?human-script=T`)
+      .get(`/v1/teams/${this.workspaceId}/databases/${id}?humanScript=T`)
       .then((response) => response.data)
       .catch((error) => handleAxiosError(error, 'Failed to fetch database'))
   }
@@ -136,7 +136,7 @@ export class NinoxClient {
 
   public async patchDatabaseSchemaInNinox(id: string, schema: DatabaseSchemaType): Promise<unknown> {
     return this.client
-      .patch(`/v1/teams/${this.workspaceId}/databases/${id}/schema?human-script=T`, schema)
+      .patch(`/v1/teams/${this.workspaceId}/databases/${id}/schema?humanScript=T`, schema)
       .then((response) => response.data)
       .catch((error) =>
         handleAxiosError(

--- a/src/core/utils/ninox-client.ts
+++ b/src/core/utils/ninox-client.ts
@@ -64,7 +64,7 @@ export class NinoxClient {
 
   public async getDatabase(id: string): Promise<GetDatabaseResponse> {
     return this.client
-      .get(`/v1/teams/${this.workspaceId}/databases/${id}?human=T`)
+      .get(`/v1/teams/${this.workspaceId}/databases/${id}?human-script=T`)
       .then((response) => response.data)
       .catch((error) => handleAxiosError(error, 'Failed to fetch database'))
   }
@@ -95,7 +95,7 @@ export class NinoxClient {
 
   public async patchDatabaseSchemaInNinox(id: string, schema: DatabaseSchemaType): Promise<unknown> {
     return this.client
-      .patch(`/v1/teams/${this.workspaceId}/databases/${id}/schema?human=T`, schema)
+      .patch(`/v1/teams/${this.workspaceId}/databases/${id}/schema?human-script=T`, schema)
       .then((response) => response.data)
       .catch((error) =>
         handleAxiosError(

--- a/src/core/utils/ninox-client.ts
+++ b/src/core/utils/ninox-client.ts
@@ -52,7 +52,7 @@ export class NinoxClient {
         })
       })
     } catch (error) {
-      // ignore 404 as the background image is optional
+      // silently ignore 404 as the background image is optional
       if (error instanceof AxiosError && error?.response?.status === axios.HttpStatusCode.NotFound) {
         error?.request?.abort()
         return
@@ -60,6 +60,47 @@ export class NinoxClient {
 
       throw error
     }
+  }
+
+  // TODO: Upload Report files is not yet supported due to the lack of use cases
+  public async downloadReportFiles(databaseId: string, reportId: string, folderPath: string): Promise<unknown> {
+    const reportFilesUrl = `/v1/teams/${this.workspaceId}/databases/${databaseId}/reports/${reportId}/files`
+
+    return this.client
+      .get(reportFilesUrl)
+      .then((response) => {
+        const files = response.data
+
+        const downloadPromises = files.map(async (filename: string) => {
+          const fileUrl = `/v1/teams/${this.workspaceId}/databases/${databaseId}/reports/${reportId}/files/${filename}`
+          await fs.promises.mkdir(folderPath, {recursive: true})
+          const writer = fs.createWriteStream(`${folderPath}/${filename}`)
+
+          return this.client({
+            method: 'GET',
+            responseType: 'stream',
+            url: fileUrl,
+          }).then((fileResponse) => {
+            fileResponse.data.pipe(writer)
+
+            return new Promise((resolve, reject) => {
+              writer.on('finish', resolve)
+              writer.on('error', reject)
+            })
+          })
+        })
+
+        return Promise.all(downloadPromises)
+      })
+      .catch((error) => {
+        // ignore 404 as the background image is optional
+        if (error instanceof AxiosError && error?.response?.status === axios.HttpStatusCode.NotFound) {
+          error?.request?.abort()
+          return
+        }
+
+        handleAxiosError(error, 'Failed to download report files')
+      })
   }
 
   public async getDatabase(id: string): Promise<GetDatabaseResponse> {

--- a/src/core/utils/util.ts
+++ b/src/core/utils/util.ts
@@ -34,3 +34,5 @@ export function getEnvironment(environment: string): EnvironmentConfig {
 
   return config.environments[environment]
 }
+
+export const isTest = (): boolean => process.env.NODE_ENV === 'test'

--- a/src/core/utils/util.ts
+++ b/src/core/utils/util.ts
@@ -1,8 +1,10 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import table from 'tty-table'
 import * as yaml from 'yaml'
 
 import {CREDENTIALS_FILE_NAME} from '../common/constants.js'
+import {DatabaseMetadata} from '../common/schema-validators.js'
 import {Config, EnvironmentConfig} from '../common/types.js'
 import {configSchema} from './config-validator.js'
 
@@ -36,3 +38,17 @@ export function getEnvironment(environment: string): EnvironmentConfig {
 }
 
 export const isTest = (): boolean => process.env.NODE_ENV === 'test'
+
+export const renderDatabaseListAsTable = (data: DatabaseMetadata[]): string => {
+  const header = [
+    {alias: '#', value: 'idx'},
+    {alias: 'Database name', align: 'left', headerAlign: 'left', value: 'name', width: 20},
+    {alias: 'Database ID', value: 'id'},
+  ]
+  const rows = data.map((database, index) => ({...database, idx: index + 1}))
+  const options = {
+    borderColor: 'green',
+    borderStyle: 'solid',
+  }
+  return table(header, rows, [], options).render()
+}

--- a/test/commands/database/download.test.ts
+++ b/test/commands/database/download.test.ts
@@ -14,7 +14,7 @@ describe('database/download', () => {
   before(() => {
     databaseJSONMock = loadJsonMock('download-database-info.json') as GetDatabaseResponse
     nock('https://mocked.example.com')
-      .get(`/v1/teams/${workspaceId}/databases/${databaseId}?formattedScripts=T`)
+      .get(`/v1/teams/${workspaceId}/databases/${databaseId}?formatScripts=T`)
       .reply(200, databaseJSONMock)
       .get(`/${workspaceId}/${databaseId}/files/background.jpg`)
       .reply(200, 'mocked-image')

--- a/test/commands/database/download.test.ts
+++ b/test/commands/database/download.test.ts
@@ -14,7 +14,7 @@ describe('database/download', () => {
   before(() => {
     databaseJSONMock = loadJsonMock('download-database-info.json') as GetDatabaseResponse
     nock('https://mocked.example.com')
-      .get(`/v1/teams/${workspaceId}/databases/${databaseId}?human-script=T`)
+      .get(`/v1/teams/${workspaceId}/databases/${databaseId}?humanScript=T`)
       .reply(200, databaseJSONMock)
       .get(`/${workspaceId}/${databaseId}/files/background.jpg`)
       .reply(200, 'mocked-image')

--- a/test/commands/database/download.test.ts
+++ b/test/commands/database/download.test.ts
@@ -18,9 +18,9 @@ describe('database/download', () => {
       .reply(200, databaseJSONMock)
       .get(`/${workspaceId}/${databaseId}/files/background.jpg`)
       .reply(200, 'mocked-image')
-      .get(`/v1/teams/${workspaceId}/databases/${databaseId}/views`)
+      .get(`/v1/teams/${workspaceId}/databases/${databaseId}/views?fullView=T`)
       .reply(200, [])
-      .get(`/v1/teams/${workspaceId}/databases/${databaseId}/reports`)
+      .get(`/v1/teams/${workspaceId}/databases/${databaseId}/reports?fullReport=T`)
       .reply(200, [])
 
     stubReadEnvironmentConfig = sinon.stub(DownloadCommand.prototype, 'readEnvironmentConfig').callsFake(() => ({

--- a/test/commands/database/download.test.ts
+++ b/test/commands/database/download.test.ts
@@ -14,7 +14,7 @@ describe('database/download', () => {
   before(() => {
     databaseJSONMock = loadJsonMock('download-database-info.json') as GetDatabaseResponse
     nock('https://mocked.example.com')
-      .get(`/v1/teams/${workspaceId}/databases/${databaseId}?humanScript=T`)
+      .get(`/v1/teams/${workspaceId}/databases/${databaseId}?formattedScripts=T`)
       .reply(200, databaseJSONMock)
       .get(`/${workspaceId}/${databaseId}/files/background.jpg`)
       .reply(200, 'mocked-image')

--- a/test/commands/database/download.test.ts
+++ b/test/commands/database/download.test.ts
@@ -14,7 +14,7 @@ describe('database/download', () => {
   before(() => {
     databaseJSONMock = loadJsonMock('download-database-info.json') as GetDatabaseResponse
     nock('https://mocked.example.com')
-      .get(`/v1/teams/${workspaceId}/databases/${databaseId}?human=T`)
+      .get(`/v1/teams/${workspaceId}/databases/${databaseId}?human-script=T`)
       .reply(200, databaseJSONMock)
       .get(`/${workspaceId}/${databaseId}/files/background.jpg`)
       .reply(200, 'mocked-image')

--- a/test/commands/database/list.test.ts
+++ b/test/commands/database/list.test.ts
@@ -24,9 +24,9 @@ describe('database/list', () => {
     .stdout()
     .command(['database list'])
     .it('list Databases', (context) => {
-      expect(context.stdout).to.contain(
-        databaseList.map((database: DatabaseMetadata) => `${database.name} ${database.id}`).join('\n'),
-      )
+      for (const database of databaseList) {
+        expect(context.stdout).to.match(new RegExp(`${database.id}`))
+      }
     })
 
   test

--- a/test/commands/database/upload.test.ts
+++ b/test/commands/database/upload.test.ts
@@ -25,7 +25,7 @@ describe('database/upload', () => {
       })
       .post(`/${mockNinoxEnvironment.workspaceId}/${databaseId}/settings/update`)
       .reply(200)
-      .patch(`/v1/teams/${mockNinoxEnvironment.workspaceId}/databases/${databaseId}/schema?human=T`)
+      .patch(`/v1/teams/${mockNinoxEnvironment.workspaceId}/databases/${databaseId}/schema?human-script=T`)
       .reply(200)
       .post(`/v1/teams/${mockNinoxEnvironment.workspaceId}/databases/${databaseId}/views`)
       .reply(200)

--- a/test/commands/database/upload.test.ts
+++ b/test/commands/database/upload.test.ts
@@ -25,7 +25,7 @@ describe('database/upload', () => {
       })
       .post(`/${mockNinoxEnvironment.workspaceId}/${databaseId}/settings/update`)
       .reply(200)
-      .patch(`/v1/teams/${mockNinoxEnvironment.workspaceId}/databases/${databaseId}/schema?human-script=T`)
+      .patch(`/v1/teams/${mockNinoxEnvironment.workspaceId}/databases/${databaseId}/schema?humanScript=T`)
       .reply(200)
       .post(`/v1/teams/${mockNinoxEnvironment.workspaceId}/databases/${databaseId}/views`)
       .reply(200)

--- a/test/commands/database/upload.test.ts
+++ b/test/commands/database/upload.test.ts
@@ -25,7 +25,7 @@ describe('database/upload', () => {
       })
       .post(`/${mockNinoxEnvironment.workspaceId}/${databaseId}/settings/update`)
       .reply(200)
-      .patch(`/v1/teams/${mockNinoxEnvironment.workspaceId}/databases/${databaseId}/schema?humanScript=T`)
+      .patch(`/v1/teams/${mockNinoxEnvironment.workspaceId}/databases/${databaseId}/schema?formattedScripts=T`)
       .reply(200)
       .post(`/v1/teams/${mockNinoxEnvironment.workspaceId}/databases/${databaseId}/views`)
       .reply(200)

--- a/test/commands/database/upload.test.ts
+++ b/test/commands/database/upload.test.ts
@@ -25,7 +25,7 @@ describe('database/upload', () => {
       })
       .post(`/${mockNinoxEnvironment.workspaceId}/${databaseId}/settings/update`)
       .reply(200)
-      .patch(`/v1/teams/${mockNinoxEnvironment.workspaceId}/databases/${databaseId}/schema?formattedScripts=T`)
+      .patch(`/v1/teams/${mockNinoxEnvironment.workspaceId}/databases/${databaseId}/schema?formatScripts=T`)
       .reply(200)
       .post(`/v1/teams/${mockNinoxEnvironment.workspaceId}/databases/${databaseId}/views`)
       .reply(200)

--- a/test/mocks/nx-project/Objects/database_4321/table_table112_/table_table112_.yaml
+++ b/test/mocks/nx-project/Objects/database_4321/table_table112_/table_table112_.yaml
@@ -4,9 +4,8 @@ table:
   caption: Table112~!   @#$%^&*`@#$%^&*()$%^&*(
   captions: {}
   fields:
-    A:
+    Text:
       base: string
-      caption: Text
       captions: {}
       required: false
       order: 0
@@ -18,9 +17,9 @@ table:
       stringAutocorrect: true
       stringMultiline: false
       height: 1
-    C:
+      _id: A
+    Birthday:
       base: string
-      caption: Birthday
       captions: {}
       required: false
       order: 2
@@ -33,9 +32,9 @@ table:
       stringAutocorrect: true
       stringMultiline: false
       height: 1
-    D:
+      _id: C
+    Father Name:
       base: string
-      caption: Father Name
       captions: {}
       required: false
       order: 3
@@ -47,9 +46,9 @@ table:
       stringAutocorrect: true
       stringMultiline: false
       height: 1
-    B:
+      _id: D
+    First Name:
       base: string
-      caption: First Name
       captions: {}
       required: false
       order: 1
@@ -61,6 +60,7 @@ table:
       stringAutocorrect: true
       stringMultiline: false
       height: 1
+      _id: B
   globalSearch: true
   hidden: false
   kind: table


### PR DESCRIPTION
Bug fixes:
- Reports and Views were downloaded separately, failing when there were many e.g 200 views because all we downloaded parallel with Promise.all. Changed to use bulk download API for Reports and Views
-  order and seq fields are made optional, due to cases found where these fields were missing in views
-  ~prevented js-yaml dump from adding line-breaks in multi-line strings by passing `{lineWidth: -1}`~
- Migrated from `js-yaml` to `yaml` as js-yaml was not printing the tab characters in scripts, vs yaml , which automatically converts tabs to spaces when printing
- Table fields were shown with keys of their fieldId e.g A,B,C . Changed it to field.caption (which is also unique) for better readability

UX improvements:
- Added spinner in all commands
- Printed Database list in a table
- Bumped version to 0.1.2

---

Related changes in Ninox Server: https://github.com/ninoxdb/ninox/pull/2489