### PR TITLE
fix: [ND-8884] bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ npm install -g @ninox/ninox
 $ ninox COMMAND
 running command...
 $ ninox (--version)
-@ninox/ninox/0.1.3 darwin-arm64 node-v20.15.0
+@ninox/ninox/0.1.4 darwin-arm64 node-v20.15.0
 $ ninox --help [COMMAND]
 USAGE
   $ ninox COMMAND
@@ -104,8 +104,6 @@ EXAMPLES
   $ ninox DEV database download -i 1234
 ```
 
-_See code: [src/commands/database/download.ts](https://github.com/ninoxdb/ninox-dev-cli/blob/v0.1.3/src/commands/database/download.ts)_
-
 ## `ninox database list`
 
 List all the database names and ids in the Ninox cloud server. The ENV argument comes before the command name.
@@ -120,8 +118,6 @@ DESCRIPTION
 EXAMPLES
   $ ninox DEV database list
 ```
-
-_See code: [src/commands/database/list.ts](https://github.com/ninoxdb/ninox-dev-cli/blob/v0.1.3/src/commands/database/list.ts)_
 
 ## `ninox database upload`
 
@@ -141,8 +137,6 @@ EXAMPLES
   $ ninox DEV database upload -i 1234
 ```
 
-_See code: [src/commands/database/upload.ts](https://github.com/ninoxdb/ninox-dev-cli/blob/v0.1.3/src/commands/database/upload.ts)_
-
 ## `ninox project init NAME`
 
 Initialize a new Ninox project in the current directory
@@ -160,8 +154,6 @@ DESCRIPTION
 EXAMPLES
   $ ninox project init
 ```
-
-_See code: [src/commands/project/init.ts](https://github.com/ninoxdb/ninox-dev-cli/blob/v0.1.3/src/commands/project/init.ts)_
 <!-- commandsstop -->
 
 # Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninox/ninox",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninox/ninox",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ninox/ninox",
   "description": "Ninox Database CLI for developer workflows",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publishConfig": {
     "access": "public"
   },

--- a/src/core/common/types.ts
+++ b/src/core/common/types.ts
@@ -102,3 +102,7 @@ export type TableFolderContent = {
 export type ContextOptions = {
   debug: (message: string) => void
 }
+
+export type SchemaPatchResponse = {
+  version: number
+}

--- a/src/core/services/database-service.ts
+++ b/src/core/services/database-service.ts
@@ -1,5 +1,5 @@
 import {DatabaseMetadata, DatabaseSchemaType, DatabaseType, Report, ViewType} from '../common/schema-validators.js'
-import {ContextOptions} from '../common/types.js'
+import {ContextOptions, SchemaPatchResponse} from '../common/types.js'
 import {NinoxClient} from '../utils/ninox-client.js'
 import {INinoxObjectService, IProjectService} from './interfaces.js'
 
@@ -89,7 +89,10 @@ export class DatabaseService implements INinoxObjectService<DatabaseMetadata> {
       tables,
       views: viewsLocal,
     })
-    await this.uploadDatabase(database, schema, views, reports)
+    const newVersion = await this.uploadDatabase(database, schema, views, reports)
+    if (Number.isFinite(newVersion)) {
+      await ninoxProjectService.writeDatabaseFile(database, {...schema, version: newVersion})
+    }
   }
 
   public async uploadDatabase(
@@ -97,7 +100,7 @@ export class DatabaseService implements INinoxObjectService<DatabaseMetadata> {
     schema: DatabaseSchemaType,
     views: ViewType[],
     reports: Report[],
-  ): Promise<void> {
+  ): Promise<number> {
     if (!this.databaseId) throw new Error('Database ID is required to upload the database')
     const isUploaded = await this.ninoxClient.uploadDatabaseBackgroundImage(
       this.databaseId,
@@ -111,10 +114,11 @@ export class DatabaseService implements INinoxObjectService<DatabaseMetadata> {
       database.settings.backgroundClass = 'background-file'
     }
 
-    await this.ninoxClient.patchDatabaseSchemaInNinox(database.id, schema)
+    const response = (await this.ninoxClient.patchDatabaseSchemaInNinox(database.id, schema)) as SchemaPatchResponse
     await this.ninoxClient.updateDatabaseSettingsInNinox(database.id, database.settings)
     await this.ninoxClient.updateDatabaseViewsInNinox(database.id, views)
     await this.ninoxClient.updateDatabaseReportsInNinox(database.id, reports)
+    return response?.version
   }
 
   private async getDatabaseMetadataAndSchema(

--- a/src/core/services/database-service.ts
+++ b/src/core/services/database-service.ts
@@ -90,7 +90,7 @@ export class DatabaseService implements INinoxObjectService<DatabaseMetadata> {
       views: viewsLocal,
     })
     const newVersion = await this.uploadDatabase(database, schema, views, reports)
-    if (Number.isFinite(newVersion)) {
+    if (Number(newVersion)) {
       await ninoxProjectService.writeDatabaseFile(database, {...schema, version: newVersion})
     }
   }

--- a/src/core/services/interfaces.ts
+++ b/src/core/services/interfaces.ts
@@ -40,6 +40,7 @@ export interface IProjectService {
     dBConfigsYaml: DBConfigsYaml,
   ): [database: DatabaseType, schema: DatabaseSchemaType, views: ViewType[], reports: Report[]]
   readDBConfig(): Promise<DBConfigsYaml>
+  writeDatabaseFile(database: DatabaseType, schema: DatabaseSchemaBaseType): Promise<void>
   writeDatabaseToFiles(
     database: DatabaseType,
     schema: DatabaseSchemaBaseType,

--- a/src/core/services/ninoxproject-service.ts
+++ b/src/core/services/ninoxproject-service.ts
@@ -331,6 +331,25 @@ export class NinoxProjectService implements IProjectService {
   }
 
   // Write the database, schema and tables to their respective files
+  public async writeDatabaseFile(database: DatabaseType, schema: DatabaseSchemaBaseType): Promise<void> {
+    const databaseFilePath = path.join(
+      this.getDatabaseObjectsPath(),
+      `${this.fsUtil.formatObjectFilename('database', database.settings.name)}.yaml`,
+    )
+    await this.fsUtil.writeFile(
+      databaseFilePath,
+      yaml.stringify(
+        DatabaseFile.parse({
+          database: {
+            ...database,
+            schema: {...schema, _database: database.id},
+          },
+        }),
+        YAML_DEFAULT_OPTIONS,
+      ),
+    )
+  }
+
   // eslint-disable-next-line max-params
   public async writeDatabaseToFiles(
     database: DatabaseType,
@@ -455,25 +474,6 @@ export class NinoxProjectService implements IProjectService {
     }
 
     return this.fsUtil.readFile(path.join(this.databaseObjectsPath, databaseFile))
-  }
-
-  private async writeDatabaseFile(database: DatabaseType, schema: DatabaseSchemaBaseType): Promise<void> {
-    const databaseFilePath = path.join(
-      this.getDatabaseObjectsPath(),
-      `${this.fsUtil.formatObjectFilename('database', database.settings.name)}.yaml`,
-    )
-    await this.fsUtil.writeFile(
-      databaseFilePath,
-      yaml.stringify(
-        DatabaseFile.parse({
-          database: {
-            ...database,
-            schema: {...schema, _database: database.id},
-          },
-        }),
-        YAML_DEFAULT_OPTIONS,
-      ),
-    )
   }
 
   private async writeReportsToFiles(


### PR DESCRIPTION
- Ninox CLI: Database Upload. There is a need to manually update the version, everytime a update is made from the CLI. After uploading a Database, the new version is returned from the PatchSchema API and is written to the Database file, so that version is insync when updates are done from one end.