### PR TITLE
feat: [ND-9486] Ninox CLI: Remove seq field from the Schema config

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ npm install -g @ninox/ninox
 $ ninox COMMAND
 running command...
 $ ninox (--version)
-@ninox/ninox/0.1.6 darwin-arm64 node-v20.15.0
+@ninox/ninox/0.1.7 darwin-arm64 node-v20.17.0
 $ ninox --help [COMMAND]
 USAGE
   $ ninox COMMAND

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninox/ninox",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninox/ninox",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ninox/ninox",
   "description": "Ninox Database CLI for developer workflows",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "publishConfig": {
     "access": "public"
   },

--- a/src/core/common/schema-validators.ts
+++ b/src/core/common/schema-validators.ts
@@ -41,7 +41,6 @@ export const DatabaseSchemaBase = z.object({
     )
     .optional(),
   nextTypeId: z.number(),
-  seq: z.number(),
   version: z.number(),
 })
 
@@ -119,7 +118,6 @@ export const DatabaseSchemaForUpload = z.object({
       }),
     )
     .optional(),
-  seq: z.number().optional(),
   version: z.number(),
 })
 
@@ -208,7 +206,6 @@ export const ViewTypeSchema = z.object({
   kanbanDisableCreate: z.boolean().optional(),
   mode: z.string().optional(),
   order: z.number().optional(),
-  seq: z.number().optional(),
   type: z.string(),
 })
 
@@ -223,7 +220,6 @@ const minimalReportSchema = z.object({
   caption: z.string(),
   id: z.string(),
   nids: z.array(z.string()).optional(),
-  seq: z.number().optional(),
   tid: z.string(),
 })
 
@@ -282,7 +278,6 @@ const carboneReportSchema = minimalReportSchema.extend({
   // eslint-disable-next-line perfectionist/sort-objects
   pdfPassword: z.string().optional(),
   setPassword: z.boolean().optional(),
-  // seq: z.number().optional(),
 })
 
 export const reportSchema = z.union([normalReportSchema, carboneReportSchema])

--- a/src/core/services/database-service.spec.ts
+++ b/src/core/services/database-service.spec.ts
@@ -22,7 +22,6 @@ describe('DatabaseService', () => {
     hideSearch: false,
     knownDatabases: [],
     nextTypeId: 1,
-    seq: 1,
     types: {},
     version: 1,
   }

--- a/src/core/services/ninoxproject-service.spec.ts
+++ b/src/core/services/ninoxproject-service.spec.ts
@@ -48,7 +48,6 @@ describe('NinoxProjectService', () => {
     hideSearch: false,
     knownDatabases: [],
     nextTypeId: 2,
-    seq: 92,
     version: 33,
   }
 

--- a/test/common/test-utils.ts
+++ b/test/common/test-utils.ts
@@ -51,7 +51,6 @@ export const testSchemaBase: DatabaseSchemaBaseType = {
   hideSearch: false,
   knownDatabases: [],
   nextTypeId: 2,
-  seq: 92,
   version: 33,
 }
 

--- a/test/mocks/nx-project/Objects/database_4321/database_7814.yaml
+++ b/test/mocks/nx-project/Objects/database_4321/database_7814.yaml
@@ -19,6 +19,5 @@ database:
     hideSearch: false
     knownDatabases: []
     nextTypeId: 2
-    seq: 92
     version: 33
     _database: "4321"


### PR DESCRIPTION
- Removed seq field from Database configuration files, as it was not needed and it keeps increasing and thus may confuse the user.
- Updated test data to match it.